### PR TITLE
feat: Allow file / folder patterns in WalkNodeOptions

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -282,6 +282,25 @@ it('should ignore node_modules', async function() {
     assert.equal(nodeModules.length, 0, 'node_modules in filepath');
 });
 
+it('should accept ignore patterns', async function() {
+    const ignorePatterns = ['ok.ts', 'large-data-dump' ];
+    result = await main(`${rootPath}/fixtures`, { type: 'directory', ignorePatterns });
+
+    assert.equal(result.filter(m => !m.name).length, 0, 'Missing names');
+
+    const ts = result.filter(item => item.module === 'typescript');
+    assert.equal(ts.length, 0, 'Typescript modules');
+
+    const xDir = result.find(({ filepath }) => filepath.indexOf('/large-data-dump/') !== -1);
+    assert.equal(xDir, null, 'did not ignore "large-data-dump" dir');
+
+    const okFile = result.find(({ filepath }) => filepath.indexOf('ok.ts') !== -1);
+    assert.equal(okFile, null, 'did not ignore "ok.ts" file');
+
+    const nodeModules = result.filter(item => item.filepath && item.filepath.indexOf('node_modules') !== -1);
+    assert.equal(nodeModules.length, 0, 'node_modules in filepath');
+});
+
 it('node core with additional functions', async () => {
     result = await main(`
         declare module "assert" {


### PR DESCRIPTION
The `recursive-readdir` package supports this out of the box, so it's just a matter of propagating that down.

Motivation:
The process can die (out of memory) when traversing very large trees.
I have a project in which I've mounted a git / sublime ignored volume in the typescript project.
I use sublime-import-helper, and when walking the 100+GB folder, the process crashes. It's an ignored folder in sublime, so pending (hopefully) this PR, it would make sense to pass in sublime's ignored folders to ImportHelper so that the imports still work.

Assuming this makes it in, I will open that PR next.